### PR TITLE
🔧 Fix Pydantic settings validation for extra environment variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,15 @@ mcp__git__git_status         # Check repository status
 mcp__git__git_add           # Stage changes
 mcp__git__git_commit        # Create commits
 
+# Git branch management workflow
+# When working on fixes or features:
+git stash push -m "WIP: Description of changes"  # Stash current work
+git checkout -b fix/branch-name main             # Create feature/fix branch
+git stash pop                                    # Apply stashed changes
+# ... work on changes ...
+git add . && git commit -m "Fix: description"    # Commit changes
+git push -u origin fix/branch-name               # Push branch and create PR
+
 # Memory management (via MCP)
 mcp__memory__create_entities # Document new components
 mcp__memory__search_nodes   # Find relevant information

--- a/cargoshipper_mcp/config/settings.py
+++ b/cargoshipper_mcp/config/settings.py
@@ -81,6 +81,7 @@ class Settings(BaseSettings):
         """Pydantic configuration"""
         env_file = ".env"
         env_file_encoding = "utf-8"
+        extra = "ignore"  # Ignore extra environment variables
 
 
 # Global settings instance


### PR DESCRIPTION
## Summary
- Fix Pydantic ValidationError preventing MCP server startup when extra environment variables are present
- Add `extra = "ignore"` to Settings Config class
- Document git branch workflow procedures in CLAUDE.md

## Problem
Users were experiencing this error when starting the MCP server:
```
pydantic_core._pydantic_core.ValidationError: 8 validation errors for Settings
trowel_web_builder_port
  Extra inputs are not permitted [type=extra_forbidden, input_value='5000', input_type=str]
```

## Solution
- Configure Pydantic settings to ignore extra environment variables
- This allows the CargoShipper MCP server to coexist with other projects that set environment variables

## Testing
- ✅ All local tests pass (4/4)
- ✅ Settings load correctly with extra environment variables
- ✅ MCP server starts successfully
- ✅ No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)